### PR TITLE
[#35] return a list of orgs and roles for a given user

### DIFF
--- a/ckanext/cadastaroles/logic/action/get.py
+++ b/ckanext/cadastaroles/logic/action/get.py
@@ -6,7 +6,6 @@ from ckanext.cadastaroles.logic import schema
 
 
 @toolkit.side_effect_free
-@validate(schema.user_role_show)
 def user_role_show(context, data_dict):
     model = context['model']
     session = context['session']

--- a/ckanext/cadastaroles/logic/action/get.py
+++ b/ckanext/cadastaroles/logic/action/get.py
@@ -5,6 +5,7 @@ from ckan.plugins import toolkit
 from ckanext.cadastaroles.logic import schema
 
 
+@validate(schema.user_role_show)
 @toolkit.side_effect_free
 def user_role_show(context, data_dict):
     model = context['model']
@@ -15,16 +16,20 @@ def user_role_show(context, data_dict):
         .filter(model.Member.table_name == 'user')\
         .filter(model.Member.table_id == user.id)\
         .filter(model.Member.state == 'active')
+
+    organization_id = data_dict.get('organization_id')
+    if organization_id:
+        members = members.filter(model.Member.group_id == organization_id)
     result = []
     for member in members:
         membership = {
             'role': member.capacity,
             'organization': toolkit.get_action('organization_show')(data_dict={
                 'include_datasets': True,
-                'include_tags': False,
-                'include_users': False,
-                'include_groups': False,
-                'include_followers': False,
+                'include_tags': data_dict.get('include_tags', False),
+                'include_users': data_dict.get('include_users', False),
+                'include_groups': data_dict.get('include_groups', False),
+                'include_followers': data_dict.get('include_followers', False),
                 'id': member.group_id})
         }
 

--- a/ckanext/cadastaroles/logic/schema.py
+++ b/ckanext/cadastaroles/logic/schema.py
@@ -23,7 +23,6 @@ def org_id_or_name_exists(reference, context):
 
 def user_role_show():
     return {
-        'user_id': [not_missing, unicode, user_exists, as_user_id],
         'organization_id': [not_missing, unicode, org_id_or_name_exists,
                             as_org_id],
     }

--- a/ckanext/cadastaroles/logic/schema.py
+++ b/ckanext/cadastaroles/logic/schema.py
@@ -21,13 +21,6 @@ def org_id_or_name_exists(reference, context):
     return reference
 
 
-def user_role_show():
-    return {
-        'organization_id': [not_missing, unicode, org_id_or_name_exists,
-                            as_org_id],
-    }
-
-
 def cadasta_admin_schema():
     return {
         'username': [not_missing, unicode, user_exists],

--- a/ckanext/cadastaroles/logic/schema.py
+++ b/ckanext/cadastaroles/logic/schema.py
@@ -21,6 +21,13 @@ def org_id_or_name_exists(reference, context):
     return reference
 
 
+def user_role_show():
+    return {
+        'organization_id': [ignore_missing, unicode, org_id_or_name_exists,
+                            as_org_id],
+    }
+
+
 def cadasta_admin_schema():
     return {
         'username': [not_missing, unicode, user_exists],

--- a/ckanext/cadastaroles/tests/logic/action/test_get.py
+++ b/ckanext/cadastaroles/tests/logic/action/test_get.py
@@ -4,7 +4,7 @@ from ckan.lib import search
 from ckan import model
 from ckanext.cadastaroles.tests.helpers import CadastaRolesTestBase
 
-from nose.tools import assert_equal, assert_is_none, assert_raises
+from nose.tools import assert_equal, assert_raises
 
 
 class TestCadastaUserRoleShow(CadastaRolesTestBase):
@@ -17,6 +17,8 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
         organization = factories.Organization(id='1',
                                               users=[{'name': user['name'],
                                                       'capacity': 'surveyor'}])
+        dataset = factories.Dataset(owner_org=organization['id'],
+                                    name='test')
 
         context = {
             'model': model,
@@ -30,15 +32,18 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
             organization_id=organization['id'],
         )
 
-        assert_equal('surveyor', result['role'])
-        assert_equal(organization['id'], result['organization_id'])
-        assert_equal(user['id'], result['user_id'])
+        assert_equal('surveyor', result[0]['role'])
+        assert_equal(organization['id'], result[0]['organization']['id'])
+        assert_equal(dataset['id'],
+                     result[0]['organization']['packages'][0]['id'])
 
     def test_user_role_show_by_name(self):
         user = factories.User()
         organization = factories.Organization(id='1',
                                               users=[{'name': user['name'],
                                                       'capacity': 'surveyor'}])
+        dataset = factories.Dataset(owner_org=organization['id'],
+                                    name='test')
 
         context = {
             'model': model,
@@ -52,9 +57,10 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
             organization_id=organization['name'],
         )
 
-        assert_equal('surveyor', result['role'])
-        assert_equal(organization['id'], result['organization_id'])
-        assert_equal(user['id'], result['user_id'])
+        assert_equal('surveyor', result[0]['role'])
+        assert_equal(organization['id'], result[0]['organization']['id'])
+        assert_equal(dataset['id'],
+                     result[0]['organization']['packages'][0]['id'])
 
     def test_no_member_found(self):
         user = factories.User()
@@ -71,7 +77,7 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
             user_id=user['id'],
             organization_id=organization['id'],
         )
-        assert_is_none(result)
+        assert_equal(result, [])
 
     def test_org_does_not_exist_raises_validation(self):
         user = factories.User()
@@ -87,19 +93,3 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
                       context=context,
                       user_id=user['id'],
                       organization_id='no')
-
-    def test_user_does_not_exist_raises_validation(self):
-        user = factories.User()
-        organization = factories.Organization(id='1')
-
-        context = {
-            'model': model,
-            'session': model.Session,
-            'user': user['name']
-        }
-        assert_raises(toolkit.ValidationError,
-                      helpers.call_action,
-                      'user_role_show',
-                      context=context,
-                      user_id='nope',
-                      organization_id=organization['id'])

--- a/ckanext/cadastaroles/tests/logic/action/test_get.py
+++ b/ckanext/cadastaroles/tests/logic/action/test_get.py
@@ -76,3 +76,34 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
             organization_id=organization['id'],
         )
         assert_equal(result, [])
+
+    def test_user_role_by_org(self):
+        user = factories.User()
+        organization = factories.Organization(id='1',
+                                              users=[{'name': user['name'],
+                                                      'capacity': 'surveyor'}])
+        organization_2 = factories.Organization(id='2',
+                                                users=[{'name': user['name'],
+                                                        'capacity': 'surveyor'}]
+                                                )
+        dataset = factories.Dataset(owner_org=organization['id'],
+                                    name='test')
+
+        context = {
+            'model': model,
+            'session': model.Session,
+            'user': user['name']
+        }
+        result = helpers.call_action(
+            'user_role_show',
+            context=context,
+            user_id=user['name'],
+            organization_id='1',
+        )
+
+        assert_equal('surveyor', result[0]['role'])
+        assert_equal(organization['id'], result[0]['organization']['id'])
+        assert_equal(dataset['id'],
+                     result[0]['organization']['packages'][0]['id'])
+
+        assert_equal(1, len(result))

--- a/ckanext/cadastaroles/tests/logic/action/test_get.py
+++ b/ckanext/cadastaroles/tests/logic/action/test_get.py
@@ -29,7 +29,6 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
             'user_role_show',
             context=context,
             user_id=user['id'],
-            organization_id=organization['id'],
         )
 
         assert_equal('surveyor', result[0]['role'])
@@ -54,7 +53,6 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
             'user_role_show',
             context=context,
             user_id=user['name'],
-            organization_id=organization['name'],
         )
 
         assert_equal('surveyor', result[0]['role'])
@@ -78,18 +76,3 @@ class TestCadastaUserRoleShow(CadastaRolesTestBase):
             organization_id=organization['id'],
         )
         assert_equal(result, [])
-
-    def test_org_does_not_exist_raises_validation(self):
-        user = factories.User()
-
-        context = {
-            'model': model,
-            'session': model.Session,
-            'user': user['name']
-        }
-        assert_raises(toolkit.ValidationError,
-                      helpers.call_action,
-                      'user_role_show',
-                      context=context,
-                      user_id=user['id'],
-                      organization_id='no')

--- a/ckanext/project/plugin/organization.py
+++ b/ckanext/project/plugin/organization.py
@@ -62,13 +62,15 @@ class CadastaOrganization(plugins.SingletonPlugin, DefaultOrganizationForm):
         return schema
 
     def db_to_form_schema(self, group_type=None):
+        packages_schema = project_schema.project_show_schema()
+        packages_schema.pop('organization', '')
         schema = default_group_schema()
         schema.update({
             'orgURL': [convert_from_extras, ignore_missing, unicode],
             'contact': [convert_from_extras, ignore_missing, unicode],
             'ona_api_token': [convert_from_extras, ignore_missing, unicode],
             'cadasta_id': [convert_from_extras, ignore_missing, unicode],
-            'packages': project_schema.project_show_schema()
+            'packages': packages_schema,
         })
         return schema
 


### PR DESCRIPTION
@rgwozdz  is this close to what you are looking for?
```
$ ckanapi action user_role_show organization_id=org
[
  {
    "organization": {
      "approval_status": "approved",
      "description": "",
      "extras": [],
      "id": "ff0d446c-0d20-40a0-a948-41b608d04e93",
      "image_display_url": "",
      "image_url": "",
      "is_organization": true,
      "name": "org",
      "package_count": 1,
      "packages": [
        {
          "author": null,
          "author_email": null,
          "creator_user_id": "4b57cfd2-cf21-444e-b434-f023e3881ae1",
          "id": "99d30b79-b242-424e-af01-f75f788cca14",
          "isopen": false,
          "license_id": null,
          "license_title": null,
          "maintainer": null,
          "maintainer_email": null,
          "metadata_created": "2015-10-22T18:15:11.107869",
          "metadata_modified": "2015-10-22T18:15:11.125274",
          "name": "project",
          "notes": null,
          "num_resources": 0,
          "num_tags": 0,
          "owner_org": "ff0d446c-0d20-40a0-a948-41b608d04e93",
          "private": false,
          "revision_id": "39cb8701-65f9-4a4c-996e-1bb579bb4ff2",
          "state": "active",
          "title": "project",
          "type": "dataset",
          "url": null,
          "version": null
        }
      ],
      "state": "active",
      "title": "test",
      "type": "organization"
    },
    "role": "admin"
  }
]
```