### PR TITLE
[#7] add back in is required

### DIFF
--- a/ckanext/project/templates/project/snippets/project_basic_fields.html
+++ b/ckanext/project/templates/project/snippets/project_basic_fields.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
     {% block package_basic_fields_title %}
-      {{ form.input('title', id='field-title', label=_('Title '), placeholder=_('eg. A descriptive title'), value=data.title, error=errors.title, classes=['control-full', 'control-large', 'cadasta-input', 'title'], attrs={'data-module': 'slug-preview-target'}) }}
+      {{ form.input('title', id='field-title', label=_('Title '), placeholder=_('eg. A descriptive title'), value=data.title, error=errors.title, classes=['control-full', 'control-large', 'cadasta-input', 'title'], attrs={'data-module': 'slug-preview-target'}, is_required=true) }}
     {% endblock %}
     {% block package_basic_fields_url %}
       {{ form.hidden('name', value=data.name) }}


### PR DESCRIPTION
@sbindman , looks like this minor change was lost in a merge, although the required field message was removed in https://github.com/Cadasta/ckanext-project/commit/70038d59fc484bd0eb7fdcbbc77fa36a041a363b#diff-29f19e71f100af07e7f4df51e82e5020