### PR TITLE
Attempting fix for #162.

### DIFF
--- a/ckanext/project/public/shared/src/services/utilityService.js
+++ b/ckanext/project/public/shared/src/services/utilityService.js
@@ -16,7 +16,7 @@ var app = angular.module("app")
              */
             var date = dateString.split("-").join("/")
                                     .replace(/\..*/g,'')
-                                    .replace(/\+[0-9]+$/g,'')
+                                    .replace(/\+.*/g,'')
                                     .replace(/T/,' ');
             var date_object = new Date(date);
             var month = date_object.getMonth() + 1;


### PR DESCRIPTION
Truncate date string after either '.' or '+'. Seems to work on Chrome and Firefox but dates in the system are inconsistent so ymmv. Might be better using something like moment.js?